### PR TITLE
使用spl库编写观察者模式

### DIFF
--- a/patterns/observer/spl/Observable.php
+++ b/patterns/observer/spl/Observable.php
@@ -1,0 +1,71 @@
+<?php
+namespace spl;
+
+/**
+ * 被观察者实体类
+ *
+ * 实现附加观察者，删除观察者，通知观察者方法
+ */
+class Observable implements \SplSubject
+{
+    /**
+     * 观察者们
+     * @var array
+     */
+    private $_observers = [];
+
+    private $_message = "通知消息";
+
+    /**
+     * 附加观察者
+     * @param \SplObserver $observer
+     * @return void
+     */
+    public function attach(\SplObserver $observer)
+    {
+        if (!in_array($observer, $this->_observers, true)) {
+            $this->_observers[] = $observer;
+        }
+    }
+
+    /**
+     * 解除观察者
+     * @param \SplObserver $observer
+     * @return void
+     */
+    public function detach(\SplObserver $observer)
+    {
+        foreach ($this->_observers as $k => $v) {
+            if ($v === $observer) {
+                unset($this->_observers[$k]);
+            }
+        }
+    }
+
+    /**
+     * 通知观察者
+     * @return void
+     */
+    public function notify()
+    {
+        foreach ($this->_observers as $observer) {
+            $observer->update($this);
+        }
+    }
+
+
+    /**
+     * 获取消息
+     * @return string
+     */
+    public function getMessage()
+    {
+       return $this->_message;
+    }
+
+    public function setMessage($msg)
+    {
+        $this->_message = $msg;
+    }
+}
+

--- a/patterns/observer/spl/ObserverExampleOne.php
+++ b/patterns/observer/spl/ObserverExampleOne.php
@@ -1,0 +1,18 @@
+<?php
+namespace spl;
+
+/**
+ * 观察者实体类示例1
+ */
+class ObserverExampleOne implements \SplObserver
+{
+    /**
+     * 行为
+     * @param \SplSubject $observable
+     * @return mixed
+     */
+    public function update(\SplSubject $observable)
+    {
+        echo $observable->getMessage() . "通知了观察者1 \n";
+    }
+}

--- a/patterns/observer/spl/ObserverExampleTwo.php
+++ b/patterns/observer/spl/ObserverExampleTwo.php
@@ -1,0 +1,18 @@
+<?php
+namespace spl;
+
+/**
+ * 观察者实体类示例1
+ */
+class ObserverExampleTwo implements \SplObserver
+{
+    /**
+     * 行为
+     * @param \SplSubject $observable
+     * @return mixed
+     */
+    public function update(\SplSubject $observable)
+    {
+        echo $observable->getMessage() . "通知了观察者2 \n";
+    }
+}

--- a/patterns/observer/spl/test.php
+++ b/patterns/observer/spl/test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * 行为型模式
+ *
+ * php观察者模式
+ * 观察者观察被观察者，被观察者通知观察者
+ *
+ * @author jealone <https://github.com/jealone>
+ * @example 运行 php test.php
+ */
+
+
+// 注册自加载
+spl_autoload_register('autoload');
+
+function autoload($class)
+{
+    require dirname($_SERVER['SCRIPT_FILENAME']) . '//..//' . str_replace('\\', '/', $class) . '.php';
+}
+
+/************************************* test *************************************/
+
+use spl\Observable;
+use spl\ObserverExampleOne;
+use spl\ObserverExampleTwo;
+
+// 注册一个被观察者对象
+$observable = new Observable();
+// 注册观察者们
+$observerExampleOne = new ObserverExampleOne();
+$observerExampleTwo = new ObserverExampleTwo();
+
+// 附加观察者
+$observable->attach($observerExampleOne);
+$observable->attach($observerExampleTwo);
+
+// 被观察者通知观察者们
+$observable->notify();


### PR DESCRIPTION
Standard PHP Library（PHP标准库) 中已经内置了观察者的相关接口
- [SplObserver](http://php.net/manual/en/class.splobserver.php)
- [SplSubject](http://php.net/manual/en/class.splsubject.php)

`SplSubject`相当于代码中`ObservableInterface`接口
`SplSubject`相当于`ObserverInterface`接口

> 使用SPL库编写观察者可以简化观察者的实现