### PR TITLE
代理模式

### DIFF
--- a/patterns/proxy/common/Proxy.php
+++ b/patterns/proxy/common/Proxy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace common;
+
+class Proxy implements Subject {
+
+    private $subject = null;
+
+    /**
+     * Proxy constructor.
+     */
+    public function __construct(Subject $_subject) {
+        $this->subject = $_subject;
+    }
+
+    public function doSomething() {
+        $this->subject->doSomething();
+    }
+
+}

--- a/patterns/proxy/common/RealSubject.php
+++ b/patterns/proxy/common/RealSubject.php
@@ -1,0 +1,12 @@
+<?php
+namespace common;
+
+
+class RealSubject implements Subject {
+
+    public function doSomething()
+    {
+        echo "具体的对象处理过程\n";
+    }
+
+}

--- a/patterns/proxy/common/Subject.php
+++ b/patterns/proxy/common/Subject.php
@@ -1,0 +1,6 @@
+<?php
+namespace common;
+
+interface Subject {
+    public function doSomething();
+}

--- a/patterns/proxy/common/test.php
+++ b/patterns/proxy/common/test.php
@@ -1,0 +1,32 @@
+<?php
+
+// 注册自加载
+spl_autoload_register('autoload');
+
+function autoload($class)
+{
+    require dirname($_SERVER['SCRIPT_FILENAME']) . '//..//' . str_replace('\\', '/', $class) . '.php';
+}
+
+/************************************* test *************************************/
+
+use common\Subject;
+use common\RealSubject;
+use common\Proxy;
+
+
+try {
+    echo "未加代理之前：\n";
+    // 生产运动鞋
+    $subject = new RealSubject();
+    $subject->doSomething();
+
+    echo "\n--------------------\n";
+
+    echo "加代理：\n";
+    $proxy = new Proxy($subject);
+    // 代工厂生产运动鞋
+    $proxy->doSomething();
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/patterns/proxy/common/test.php
+++ b/patterns/proxy/common/test.php
@@ -10,7 +10,6 @@ function autoload($class)
 
 /************************************* test *************************************/
 
-use common\Subject;
 use common\RealSubject;
 use common\Proxy;
 

--- a/patterns/proxy/dynamic/InvocationHandler.php
+++ b/patterns/proxy/dynamic/InvocationHandler.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace proxy\dynamic;
+
+interface InvocationHandler
+{
+    public function invoke($obj, $method, $args);
+}

--- a/patterns/proxy/dynamic/Proxy.php
+++ b/patterns/proxy/dynamic/Proxy.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace proxy\dynamic;
+
+class Proxy {
+
+    private $cls = null;
+    private $interface = array();
+    private $handler = null;
+    private $reflection = null;
+
+    /**
+     * Proxy constructor.
+     * @param \ReflectionClass $reflection
+     * @param InvocationHandler $handler
+     */
+    private function __construct(\ReflectionClass $reflection, InvocationHandler $handler)
+    {
+        $this->cls = $reflection->getNamespaceName().$reflection->getName();
+        $methods = $reflection->getMethods(\ReflectionMethod::IS_PUBLIC);
+        foreach ($methods as &$method) {
+            $method = $method->getName();
+        }
+        unset($method);
+        $this->interface = $methods;
+        $this->handler = $handler;
+        $this->reflection = $reflection;
+    }
+
+
+    public static function newProxyInstance($object, $handler) {
+        return new self(new \ReflectionObject($object), $handler);
+    }
+
+    public static function newProxyClass($class, $handler) {
+        return new self(new \ReflectionClass($class), $handler);
+    }
+
+    function __call($name, $arguments) {
+        if (in_array($name, $this->interface)) {
+            $this->handler->invoke($this, $name, $arguments);
+        }
+    }
+
+
+}

--- a/patterns/proxy/dynamic/RealSubject.php
+++ b/patterns/proxy/dynamic/RealSubject.php
@@ -1,0 +1,12 @@
+<?php
+namespace proxy\dynamic;
+
+
+class RealSubject implements Subject {
+
+    public function doSomething()
+    {
+        echo "具体的对象处理过程\n";
+    }
+
+}

--- a/patterns/proxy/dynamic/Subject.php
+++ b/patterns/proxy/dynamic/Subject.php
@@ -1,0 +1,6 @@
+<?php
+namespace proxy\dynamic;
+
+interface Subject {
+    public function doSomething();
+}

--- a/patterns/proxy/dynamic/SubjectIH.php
+++ b/patterns/proxy/dynamic/SubjectIH.php
@@ -1,0 +1,29 @@
+<?php
+namespace proxy\dynamic;
+
+class SubjectIH implements InvocationHandler
+{
+    private $obj = null;
+
+    /**
+     * SubjectIH constructor.
+     * @param null $obj
+     */
+    public function __construct($obj)
+    {
+        $this->obj = $obj;
+    }
+
+    /**
+     * @param $proxy
+     * @param $method
+     * @param $args
+     * @return mixed
+     */
+    public function invoke($proxy, $method, $args)
+    {
+        return call_user_func_array(array($this->obj, $method), $args);
+    }
+
+
+}

--- a/patterns/proxy/dynamic/test.php
+++ b/patterns/proxy/dynamic/test.php
@@ -1,0 +1,28 @@
+<?php
+
+// 注册自加载
+spl_autoload_register('autoload');
+
+function autoload($class)
+{
+    require dirname($_SERVER['SCRIPT_FILENAME']) . '//..//..//' . str_replace('\\', '/', $class) . '.php';
+}
+
+/************************************* test *************************************/
+
+use proxy\dynamic\RealSubject;
+use proxy\dynamic\Proxy;
+use proxy\dynamic\SubjectIH;
+
+
+try {
+    echo "动态代理：\n";
+    $subject = new RealSubject();
+    $handler = new SubjectIH($subject);
+
+    $proxy = Proxy::newProxyInstance($subject, $handler);
+    $proxy->doSomething();
+    echo "\n--------------------\n";
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/patterns/proxy/enforce/Proxy.php
+++ b/patterns/proxy/enforce/Proxy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace proxy\common;
+namespace proxy\enforce;
 
 class Proxy implements Subject {
 
@@ -16,5 +16,11 @@ class Proxy implements Subject {
     public function doSomething() {
         $this->subject->doSomething();
     }
+
+    public function getProxy()
+    {
+        return $this;
+    }
+
 
 }

--- a/patterns/proxy/enforce/RealSubject.php
+++ b/patterns/proxy/enforce/RealSubject.php
@@ -1,0 +1,28 @@
+<?php
+namespace proxy\enforce;
+
+
+class RealSubject implements Subject {
+
+    private $proxy = null;
+
+    public function doSomething()
+    {
+        if ($this->isProxy())
+            echo "具体的对象处理过程\n";
+        else
+            echo "请使用代理访问";
+    }
+
+    public function getProxy()
+    {
+        $this->proxy = new Proxy($this);
+        return $this->proxy;
+
+    }
+
+    private function isProxy() {
+        return ($this->proxy instanceof Proxy);
+    }
+
+}

--- a/patterns/proxy/enforce/Subject.php
+++ b/patterns/proxy/enforce/Subject.php
@@ -1,6 +1,7 @@
 <?php
-namespace proxy\common;
+namespace proxy\enforce;
 
 interface Subject {
     public function doSomething();
+    public function getProxy();
 }

--- a/patterns/proxy/enforce/test.php
+++ b/patterns/proxy/enforce/test.php
@@ -10,8 +10,7 @@ function autoload($class)
 
 /************************************* test *************************************/
 
-use proxy\common\RealSubject;
-use proxy\common\Proxy;
+use proxy\enforce\RealSubject;
 
 
 try {
@@ -22,8 +21,8 @@ try {
 
     echo "\n--------------------\n";
 
-    echo "加代理：\n";
-    $proxy = new Proxy($subject);
+    echo "使用强制代理：\n";
+    $proxy = $subject->getProxy();
     // 代工厂生产运动鞋
     $proxy->doSomething();
 } catch (\Exception $e) {

--- a/patterns/proxy/ext/IProxy.php
+++ b/patterns/proxy/ext/IProxy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace proxy\ext;
+
+interface IProxy {
+    public function extension();
+}

--- a/patterns/proxy/ext/Proxy.php
+++ b/patterns/proxy/ext/Proxy.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace proxy\common;
+namespace proxy\ext;
 
-class Proxy implements Subject {
+class Proxy implements Subject,IProxy {
 
     private $subject = null;
 
@@ -15,6 +15,13 @@ class Proxy implements Subject {
 
     public function doSomething() {
         $this->subject->doSomething();
+        $this->extension();
     }
+
+    public function extension()
+    {
+        echo "实现一个扩展\n";
+    }
+
 
 }

--- a/patterns/proxy/ext/RealSubject.php
+++ b/patterns/proxy/ext/RealSubject.php
@@ -1,5 +1,5 @@
 <?php
-namespace proxy\common;
+namespace proxy\ext;
 
 
 class RealSubject implements Subject {

--- a/patterns/proxy/ext/Subject.php
+++ b/patterns/proxy/ext/Subject.php
@@ -1,5 +1,5 @@
 <?php
-namespace proxy\common;
+namespace proxy\ext;
 
 interface Subject {
     public function doSomething();

--- a/patterns/proxy/ext/test.php
+++ b/patterns/proxy/ext/test.php
@@ -10,13 +10,12 @@ function autoload($class)
 
 /************************************* test *************************************/
 
-use proxy\common\RealSubject;
-use proxy\common\Proxy;
+use proxy\ext\RealSubject;
+use proxy\ext\Proxy;
 
 
 try {
     echo "未加代理之前：\n";
-    // 生产运动鞋
     $subject = new RealSubject();
     $subject->doSomething();
 
@@ -24,7 +23,6 @@ try {
 
     echo "加代理：\n";
     $proxy = new Proxy($subject);
-    // 代工厂生产运动鞋
     $proxy->doSomething();
 } catch (\Exception $e) {
     echo $e->getMessage();

--- a/patterns/proxy/test.php
+++ b/patterns/proxy/test.php
@@ -24,7 +24,6 @@ function autoload($class)
 
 use proxy\Proxy;
 use proxy\ShoesSport;
-use proxy\ShoesSkateboard;
 
 try {
   echo "未加代理之前：\n";

--- a/patterns/proxy/virtual/Proxy.php
+++ b/patterns/proxy/virtual/Proxy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace proxy\virtual;
+
+class Proxy implements Subject {
+
+    private $subject = null;
+
+    public function doSomething() {
+        // 虚拟代理就是指需要的时候再初始化对象，不然只有代理没有对象
+        if ($this->subject == null)
+            $this->subject = new RealSubject();
+
+        $this->subject->doSomething();
+    }
+
+}

--- a/patterns/proxy/virtual/RealSubject.php
+++ b/patterns/proxy/virtual/RealSubject.php
@@ -1,0 +1,21 @@
+<?php
+namespace proxy\virtual;
+
+
+class RealSubject implements Subject {
+
+
+    /**
+     * RealSubject constructor.
+     */
+    public function __construct()
+    {
+        echo "初始化对象\n";
+    }
+
+    public function doSomething()
+    {
+        echo "具体的对象处理过程\n";
+    }
+
+}

--- a/patterns/proxy/virtual/Subject.php
+++ b/patterns/proxy/virtual/Subject.php
@@ -1,5 +1,5 @@
 <?php
-namespace proxy\common;
+namespace proxy\virtual;
 
 interface Subject {
     public function doSomething();

--- a/patterns/proxy/virtual/test.php
+++ b/patterns/proxy/virtual/test.php
@@ -10,21 +10,13 @@ function autoload($class)
 
 /************************************* test *************************************/
 
-use proxy\common\RealSubject;
-use proxy\common\Proxy;
+use proxy\virtual\Proxy;
 
 
 try {
-    echo "未加代理之前：\n";
-    // 生产运动鞋
-    $subject = new RealSubject();
-    $subject->doSomething();
 
-    echo "\n--------------------\n";
-
-    echo "加代理：\n";
-    $proxy = new Proxy($subject);
-    // 代工厂生产运动鞋
+    echo "使用虚拟加代理：\n";
+    $proxy = new Proxy();
     $proxy->doSomething();
 } catch (\Exception $e) {
     echo $e->getMessage();


### PR DESCRIPTION
代理模式的原代码中其实相当于实现的是一个不标准的虚拟代理，作用是通过代理来来驱动对象操作，并且延后代理对象实例化时间

标准的代理模式代理和对象应该实现同样的接口

PR提供了普通代理模式，强制代理，虚拟代理，代理模式扩展以及动态代理